### PR TITLE
Clamp reco deviation in relative position

### DIFF
--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -61,7 +61,8 @@ def test_scatter_batch_properties(scatter_batch):
 
     assert sb.hits["above"]["z"].shape == mu.get_hits(LW)["above"]["z"].shape
 
-    assert (loc_unc := sb.location_unc.mean() / sb.location.abs().mean()) < 10
+    assert (loc_unc := sb.location_unc[:, :2].mean()) < 0.5
+    assert (loc_unc := sb.location_unc[:, 2].mean()) < 0.5
     assert (dxy_unc := (sb.dxy_unc / sb.dxy).abs().mean()) < 10
     assert (dtheta_unc := (sb.dtheta_unc / sb.dtheta).mean()) < 10
     assert (theta_out_unc := sb.theta_out_unc.mean() / sb.theta_out.abs().mean()) < 10
@@ -164,7 +165,6 @@ def test_x0_inferer_methods(scatter_batch):
     assert p.shape == true.shape
     assert w.shape == true.shape
     mask = p == p
-    print(p)
     assert (((p - true)[mask]).abs() / true[mask]).mean() < 100
 
     p2, w2 = inferer.pred_x0()

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -107,8 +107,10 @@ def test_detector_layer(batch):
     assert hits["above"]["xy"].shape == torch.Size([batch.get_xy_mask(LW).sum(), 1, 2])
     assert torch.abs(hits["above"]["z"][0, 0, 0] - Z + (SZ / 2)) < 1e-5  # Hits located at z-centre of layer
 
+    # every reco hit (x,y) is function of resolution
     grad = jacobian(hits["above"]["xy"][:, 0], dl.resolution).sum((-1, -2))
-    assert ((grad == grad) * (grad != 0)).sum() == 2 * len(grad)  # every reco hit (x,y) is function of resolution
+    assert (grad == grad).sum() == 2 * len(grad)
+    assert ((grad == grad) * (grad != 0)).sum() > 0  # every reco hit (x,y) is function of resolution
 
 
 def get_layers():
@@ -184,4 +186,5 @@ def test_volume_forward(batch):
 
     for i, l in enumerate(volume.get_detectors()):
         grad = jacobian(hits["above" if l.z > 0.5 else "below"]["xy"][:, i % 2], l.resolution).sum((-1, -2))
-        assert ((grad == grad) * (grad != 0)).sum() == 2 * len(grad)  # every reco hit (x,y) is function of resolution
+        assert (grad == grad).sum() == 2 * len(grad)
+        assert ((grad == grad) * (grad != 0)).sum() > 0  # every reco hit (x,y) is function of resolution


### PR DESCRIPTION
Closes #10 
Reco hit deviations are performed in relative distance from lower-left coord of voxels, clamped between 0 and voxel width, and then transformed back to absolute position.

Test on location uncertainty is now performed on the absolute uncertainty rather than the relative.