### PR TITLE
Unc prop fix

### DIFF
--- a/tomopt/inference/scattering.py
+++ b/tomopt/inference/scattering.py
@@ -161,11 +161,9 @@ class AbsScatterBatch(metaclass=ABCMeta):
 
         # Compute unc^2 = unc_x*unc_y*dvar/dhit_x*dvar/dhit_y summing over all x,y inclusive combinations
         idxs = torch.combinations(torch.arange(0, unc.shape[-1]), with_replacement=True)
-        dv_dx_2 = jac[:, :, idxs].prod(-1)
-        unc_2 = dv_dx_2 * unc[:, :, idxs].prod(-1)
-        unc2_sum = unc_2.sum(-1)
+        unc_2 = (jac[:, :, idxs] * unc[:, :, idxs]).prod(-1)
 
-        return torch.sqrt(unc2_sum)
+        return unc_2.sum(-1).sqrt()
 
     @property
     def location(self) -> Tensor:


### PR DESCRIPTION
Closes #67 uncertainty calculations now fully include contributions from all variables (previously was missing a few off-diagonal terms in the error matrix).
Minimal change in the scatter inference uncertainties, due to only the z position being affected by both x and y hits uncertainties, but X0 uncertainties has slightly increased.

Uncertainty calculations now compute the jacobians once and cache, causing a significant speed up, e.g. scatter location uncertainty is now computed in 0.5s, whereas previously was 4s.

X0 inference is now split into sub-functions which calculate separately the X0 and its uncertainty.