### PR TITLE
Phi calc zerox fix

### DIFF
--- a/tomopt/inference/scattering.py
+++ b/tomopt/inference/scattering.py
@@ -246,12 +246,13 @@ class AbsScatterBatch(metaclass=ABCMeta):
         # Account for quadrants
         m = x < 0
         phi[m] = phi[m] + torch.pi
-        m = ((x > 0) * (y < 0)).bool()
+        m = (x > 0) * (y < 0)
         phi[m] = phi[m] + (2 * torch.pi)  # (0, 2pi)
 
         # Case when x == 0
-        m = x == 0
-        phi[m] = torch.pi / 2 * y[m].sign()
+        phi[(x == 0) * (y > 0)] = torch.pi / 2
+        phi[(x == 0) * (y < 0)] = 3 * torch.pi / 2
+
         return phi
 
     def _compute_out_var_unc(self, var: Tensor) -> Tensor:


### PR DESCRIPTION
Adds an edge-case handling for when x is zero when computing the phi angle during muon trajectory inference. Sets phi to pi/2 if y is positive, and 3pi/2 if it's negative. Tested over 5,600,000 muons and never found any NaN's or Infs, where previously there sometimes were.