### PR TITLE
Chore: adjust flake8 to catch unused imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
     rev: 3.9.1
     hooks:
     - id: flake8
+      args: [--ignore=E741 W503 E203 E501 C901]
     
   # - repo: https://github.com/pre-commit/mirrors-mypy
   #   rev: v0.812


### PR DESCRIPTION
Pre-commit flake8 has a default ignore list, which fails to catch unused imports.
This PR replaces the default list to catch such cases.