### PR TITLE
Fix: clamp panel resolution above 1e-10

### DIFF
--- a/tomopt/volume/panel.py
+++ b/tomopt/volume/panel.py
@@ -56,6 +56,7 @@ class DetectorPanel(nn.Module):
         if self.training or not self.realistic_validation:
             g = self.get_gauss()
             res = self.resolution * torch.exp(g.log_prob(xy)) / torch.exp(g.log_prob(self.xy))
+            res = torch.clamp_min(res, 1e-10)  # To avoid NaN gradients
         else:
             if mask is None:
                 mask = self.get_xy_mask(xy)


### PR DESCRIPTION
Adds a minimum resolution of 1e-10 via clamping when in training mode with non-realistic validation enabled.
This alleviates a cause of NaN gradients when muons are very far from some of the panels, but not all. (e.g. one of the panels is very small).