### PR TITLE
Fix: hardcode py micro-version

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: "3.8.0"
       - uses: psf/black@22.1.0
         with:
           args: ". --check"
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: "3.8.0"
       - uses: py-actions/flake8@v1
   
   mypy:
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: "3.8"
+        python-version: "3.8.0"
     - name: Install Dependencies
       run: |
         pip install -r requirements.txt


### PR DESCRIPTION
The new flake8 v6.0.0 requires py>=3.8.1, and tests were setup to require only py==3.8, but most devs use py==3.8.0. Hardcoding tests to require py==3.8.0.